### PR TITLE
Refactored to seperate terminal/CLI from stash clone functionality.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,17 @@ PATH
   specs:
     stash-clone-tool (1.0.0)
       colorize
+      git
       highline
+      multiblock
 
 GEM
   remote: https://rubygems.org/
   specs:
     colorize (0.7.7)
+    git (1.2.9.1)
     highline (1.7.2)
+    multiblock (0.2.1)
     rake (10.4.2)
 
 PLATFORMS
@@ -21,4 +25,4 @@ DEPENDENCIES
   stash-clone-tool!
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/bin/stash-clone-tool
+++ b/bin/stash-clone-tool
@@ -25,6 +25,22 @@ fail 'Must specify Stash username (-u).' if options[:username].nil?
 # Prompt for password if not provided on CLI
 options[:password] ||= ask('Password:  ') { |q| q.echo = '*' }
 
-# TODO: Write CLI
+@last_project = nil
 cloner = StashCloneTool::StashCloner.new(options[:stash_url], options[:username], options[:password], options[:directory])
-cloner.go
+
+cloner.clone_stash do |on|
+  on.initialize_repository do |repository, folder|
+    if @last_project != repository.project
+      puts "  - #{repository.project.name}...".light_yellow
+      @last_project = repository.project
+    end
+    puts "    - #{repository.name}...".light_yellow
+    puts "        Cloning ".light_blue + repository.clone_link(:ssh).light_white + " to ".light_blue + folder.light_white
+  end
+  on.success do |repository|
+    puts "        Cloned".light_green
+  end
+  on.failure do |repository, message|
+    puts "        #{message}".light_red
+  end
+end

--- a/lib/stash_clone_tool/clone_link.rb
+++ b/lib/stash_clone_tool/clone_link.rb
@@ -1,0 +1,12 @@
+module StashCloneTool
+  class CloneLink
+
+    attr_reader :uri, :type
+
+    def initialize(link)
+      @uri = link['href']
+      @type = link['name'].to_sym
+    end
+
+  end
+end

--- a/lib/stash_clone_tool/project.rb
+++ b/lib/stash_clone_tool/project.rb
@@ -1,0 +1,12 @@
+module StashCloneTool
+  class Project
+
+    attr_reader :name, :key, :repositories
+
+    def initialize(client, json)
+      @name = json['name']
+      @key = json['key']
+      @repositories = client.get_repositories(self)
+    end
+  end
+end

--- a/lib/stash_clone_tool/stash_api_client.rb
+++ b/lib/stash_clone_tool/stash_api_client.rb
@@ -1,0 +1,40 @@
+require 'net/http'
+require 'json'
+require 'stash_clone_tool/project'
+module StashCloneTool
+  class StashApiClient
+    include StashCloneTool
+
+    def initialize(stash_url, username, password)
+      @stash_url = stash_url
+      @username = username
+      @password = password
+    end
+
+    def projects
+      request('/rest/api/1.0/projects?limit=100')['values'].map { |json| Project.new(self, json) }
+    end
+
+    def get_repositories(project)
+      request("/rest/api/1.0/projects/#{project.key}/repos")['values'].map { |json| StashRepository.new(project, json) }
+    end
+
+    private
+
+    def request(url)
+      uri = URI("#{@stash_url}#{url}")
+      req = Net::HTTP::Get.new(uri.to_s)
+      req.basic_auth @username, @password
+      response = Net::HTTP.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') do |http|
+        http.request(req)
+      end
+      json = JSON.parse(response.body)
+      if json['errors']
+        error_msg = json['errors'].map { |e| e['message'] }.join('. ')
+        raise StashException.new(error_msg)
+      end
+      json
+    end
+
+  end
+end

--- a/lib/stash_clone_tool/stash_cloner.rb
+++ b/lib/stash_clone_tool/stash_cloner.rb
@@ -1,68 +1,36 @@
 # Stash Cloner
-require 'net/http'
-require 'json'
 require 'colorize'
+require 'git'
+require 'multiblock'
+require 'stash_clone_tool/stash_api_client'
+require 'stash_clone_tool/stash_repository'
 require 'stash_clone_tool/stash_exception'
 module StashCloneTool
+
   class StashCloner
+    include StashCloneTool
 
     def initialize(stash_url, username, password, directory)
-      @stash_url = stash_url
-      @username = username
-      @password = password
+      @stash = StashApiClient.new(stash_url, username, password)
       @directory = directory
     end
 
-    def go
-      get_projects['values'].each do |project|
-        process_project(project)
+    def clone_stash
+      wrapper = Multiblock.wrapper
+      yield(wrapper)
+      @stash.projects.each do |project|
+        project.repositories.each do |repository|
+          folder = File.join(@directory, project.key, repository.slug)
+          wrapper.call(:initialize_repository, repository, folder)
+          clone_link = repository.clone_link(:ssh)
+          if Dir.exists?(folder)
+            wrapper.call(:failure, repository, 'Target already exists')
+          else
+            Git.clone(clone_link, folder)
+            wrapper.call(:success, repository)
+          end
+        end
       end
-    end
-
-    private
-
-    def process_project(prj)
-      puts "  - #{prj['name']}...".light_yellow
-      project = request("/rest/api/1.0/projects/#{prj['key']}/repos")
-      project['values'].each do |repo|
-        process_repo(prj['key'], repo)
-      end
-    end
-
-    def process_repo(project_key, repo)
-      puts "    - #{repo['name']}...".light_yellow
-      clone_links = repo['links']['clone']
-      clone_link = clone_links.select { |l| l['name'] == 'ssh' }.first['href']
-      folder = File.join(@directory, project_key, repo['slug'])
-      git_command = "git clone #{clone_link} #{folder}"
-      puts "        Cloning ".light_blue + clone_link.light_white + " to ".light_blue + folder.light_white
-      if Dir.exists?(folder)
-        puts "        Target already exists".light_red
-      else
-        puts "        #{git_command}".light_green
-        puts
-        system(git_command)
-        puts
-      end
-    end
-
-    def request(url)
-      uri = URI("#{@stash_url}#{url}")
-      req = Net::HTTP::Get.new(uri.to_s)
-      req.basic_auth @username, @password
-      response = Net::HTTP.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') do |http|
-        http.request(req)
-      end
-      json = JSON.parse(response.body)
-      if json['errors']
-        error_msg = json['errors'].map { |e| e['message'] }.join('. ')
-        raise StashException.new(error_msg)
-      end
-      json
-    end
-
-    def get_projects
-      request('/rest/api/1.0/projects?limit=100')
     end
 
   end

--- a/lib/stash_clone_tool/stash_repository.rb
+++ b/lib/stash_clone_tool/stash_repository.rb
@@ -1,0 +1,19 @@
+require 'stash_clone_tool/clone_link'
+module StashCloneTool
+  class StashRepository
+    include StashCloneTool
+    attr_reader :name, :slug, :project
+
+    def initialize(project, repo)
+      @name = repo['name']
+      @clone_links = repo['links']['clone'].map{ |link| CloneLink.new(link)}
+      @slug = repo['slug']
+      @project = project
+    end
+
+    def clone_link(type)
+      cl = @clone_links.select { |link| link.type == type }.first
+      cl.uri
+    end
+  end
+end

--- a/lib/stash_clone_tool/version.rb
+++ b/lib/stash_clone_tool/version.rb
@@ -1,4 +1,4 @@
 # Version
 module StashCloneTool
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/stash-clone-tool.gemspec
+++ b/stash-clone-tool.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_dependency 'colorize'
   spec.add_dependency 'highline'
+  spec.add_dependency 'git'
+  spec.add_dependency 'multiblock'
 end


### PR DESCRIPTION
The core tool has been seperated into more granular classes, and the terminal output is contained within 'bin/stash-clone-tool'.

Stash clone tool can now be integrated into other projects with more ease.
